### PR TITLE
chore: add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @sanity-io/media-library


### PR DESCRIPTION
Adds a CODEOWNERS file to assign the Media Library team by default when opening PRs.