### PR TITLE
fix: avoid encoding signing parameters

### DIFF
--- a/test/signing.test.ts
+++ b/test/signing.test.ts
@@ -230,11 +230,9 @@ describe('signUrl', () => {
     const parsedUrl = new URL(signedUrl)
 
     // Create the URL that was actually signed (without the signature parameter)
-    const urlForSigning = new URL(baseUrl)
-    urlForSigning.searchParams.set('keyid', TEST_KEY_ID)
-    urlForSigning.searchParams.set('expiry', TEST_EXPIRY)
+    const urlStr = `${baseUrl}?keyid=${TEST_KEY_ID}&expiry=${TEST_EXPIRY}`
 
-    const expectedSignature = generateSignature(urlForSigning.toString(), TEST_PRIVATE_KEY)
+    const expectedSignature = generateSignature(urlStr, TEST_PRIVATE_KEY)
     const actualSignature = parsedUrl.searchParams.get('signature')
 
     expect(actualSignature).toBe(expectedSignature)


### PR DESCRIPTION
Prevents encoding signing query parameters by using string concatenation over URLSearchParams.

This is necessary as encoded expiry parameter values result in a `403 Forbidden` when accessing protected assets due to the signature failing validation.
