### PR TITLE
feat!: canonicalise query parameters and use RFC 3986 encoding

### DIFF
--- a/scripts/sign.ts
+++ b/scripts/sign.ts
@@ -1,42 +1,38 @@
-#!/usr/bin/env node
+import {existsSync, readFileSync} from 'fs'
+import {join} from 'path'
 
-import * as fs from 'fs'
-import * as path from 'path'
-
-import {generateSignature, pemToEd25519Hex, signUrl, urlWithSigningParams} from '../src/index.js'
+import {generateSignature, pemToEd25519Hex, signUrl, urlWithSigningParams} from '../src/index'
+import {extractUserParams, getCanonicalQuery} from '../src/signing'
 
 /**
  * Script to generate signature information from a PEM file
  *
- * Usage: npm run sign <path-to-pem-file> <url-to-sign> <key-id>  [expiry]
+ * Usage: npm run sign <path-to-pem-file> <url-to-sign> <key-id> [expiry]
  */
 function main() {
   const args = process.argv.slice(2)
 
-  if (args.length < 2) {
-    console.error('Usage: npm run sign <path-to-pem-file> <url-to-sign> <key-id>  [expiry]')
+  if (args.length < 3) {
+    console.error('Usage: npm run sign <path-to-pem-file> <url-to-sign> <key-id> [expiry]')
     console.error('Examples:')
-    console.error('  npm run sign ./private-key.pem "https://example.com/api/resource"')
+    console.error('  npm run sign ./private-key.pem "https://example.com/api/resource" "my-key-id"')
     console.error(
       '  npm run sign ./private-key.pem "https://example.com/api/resource" "my-key-id" "2025-12-31T23:59:59Z"',
     )
-    console.error(
-      '  npm run sign ./private-key.pem "https://example.com/api/resource" "my-key-id" "1h" # 1 hour from now',
-    )
     process.exit(1)
   }
-  const [pemPath, urlToSign, keyId, expiry] = args
+  const [pemPath, url, keyId, expiry] = args
 
   try {
     // Check if PEM file exists
-    if (!fs.existsSync(pemPath)) {
+    if (!existsSync(pemPath)) {
       console.error(`Error: PEM file not found: ${pemPath}`)
       process.exit(1)
     }
 
     // Read the PEM file
-    const pemContent = fs.readFileSync(pemPath, 'utf8')
-    console.info(`📂 Successfully loaded existing keys from ${path.join(pemPath)}`)
+    const pemContent = readFileSync(pemPath, 'utf8')
+    console.info(`📂 Successfully loaded existing keys from ${join(pemPath)}`)
 
     // Convert PEM to Ed25519 hex private key
     if (!keyId) {
@@ -46,8 +42,13 @@ function main() {
 
     const privateKeyHex = pemToEd25519Hex(pemContent)
 
-    const fullUrl = urlWithSigningParams(urlToSign, {expiry, keyId})
-    const signature = generateSignature(fullUrl, privateKeyHex)
+    const urlObj = new URL(url)
+    // Extract user-defined query parameters, excluding reserved signing parameters
+    const userParams = extractUserParams(urlObj)
+    // Canonicalize the query string from the user parameters
+    const canonicalQuery = getCanonicalQuery(userParams)
+    const urlToSign = urlWithSigningParams(urlObj, canonicalQuery, {expiry, keyId})
+    const signature = generateSignature(urlToSign, privateKeyHex)
     const signedUrl = signUrl(urlToSign, {
       expiry,
       keyId,
@@ -56,7 +57,7 @@ function main() {
 
     console.info('🔑 Signing URL with Ed25519 Key')
     console.info('   ✅ URL signed successfully')
-    console.info(`   📋 Original URL: ${fullUrl}`)
+    console.info(`   📋 Original URL: ${url}`)
     console.info(`   ⏰ Expires at: ${expiry ?? 'never'}`)
     console.info(`   🔑 Signature: ${signature}`)
     console.info(`   🌐 Signed URL: ${signedUrl}`)

--- a/src/signing.ts
+++ b/src/signing.ts
@@ -1,11 +1,27 @@
 import {etc, hashes, sign} from '@noble/ed25519'
 import {sha512} from '@noble/hashes/sha2.js'
 
-import type {SigningOptions} from './types'
+import type {Param, SigningOptions} from './types'
 
-import {normalizeExpiry, toBase64UrlWithPadding} from './utils'
+import {lexographicSort, normalizeExpiry, rfc3986, toBase64UrlWithPadding} from './utils'
 
 hashes.sha512 = sha512
+
+/**
+ * Extracts user-defined query parameters from a URL, excluding reserved signing parameters.
+ *
+ * @internal
+ * @param url - The URL from which to extract user parameters
+ * @returns An array of [key, value] tuples for user-defined parameters
+ */
+export function extractUserParams(url: URL): Param[] {
+  const reservedKeys = ['keyid', 'expiry', 'signature']
+  return url.searchParams.entries().reduce((params, param) => {
+    const key = param[0]
+    if (!reservedKeys.includes(key)) params.push(param)
+    return params
+  }, [] as Param[])
+}
 
 /**
  * Generates an Ed25519 signature for a given URL.
@@ -15,16 +31,38 @@ hashes.sha512 = sha512
  * @param privateKey - The private key to use for signing
  * @returns The base64url-encoded signature
  */
-export function generateSignature(url: string | URL, privateKey: string): string {
-  const urlStr = url.toString()
+export function generateSignature(url: string, privateKey: string): string {
   // Encode the URL as bytes
-  const urlBytes = new TextEncoder().encode(urlStr)
+  const urlBytes = new TextEncoder().encode(url)
   // Encode the private key as bytes
   const privateKeyBytes = etc.hexToBytes(privateKey)
   // Get the signed URL as bytes
   const signatureBytes = sign(urlBytes, privateKeyBytes)
   // Convert the signature to a URL-safe base64 string
-  return toBase64UrlWithPadding(signatureBytes)
+  const urlSafeSignature = toBase64UrlWithPadding(signatureBytes)
+  // Return the URL-safe signature, encoded per RFC 3986
+  return urlSafeSignature
+}
+
+/**
+ * Generates a lexicographically sorted canonical query string from parameter tuples.
+ *
+ * The canonical query string is formed by:
+ *   - Encoding each key and value per RFC 3986
+ *   - Sorting parameters lexicographically by key, then by value
+ *   - Joining as key=value pairs with '&' separation
+ *
+ * @internal
+ * @param params - An array of [key, value] parameter tuples
+ * @returns The canonical query string of user parameters
+ */
+export function getCanonicalQuery(params: Param[]): string {
+  // Encode each key and value
+  const encodedParams = params.map((param) => param.map(rfc3986) as Param)
+  // Sort params lexicographically by key, then by value
+  encodedParams.sort(lexographicSort)
+  // Join as key=value pairs with '&' separation
+  return encodedParams.map((param) => param.join('=')).join('&')
 }
 
 /**
@@ -36,14 +74,17 @@ export function generateSignature(url: string | URL, privateKey: string): string
  * @returns The signed URL
  */
 export function signUrl(url: string | URL, options: SigningOptions): string {
-  const {expiry, keyId, privateKey} = options
-  // Get the URL with signing parameters (keyid and expiry)
-  const urlWithParams = urlWithSigningParams(url, {expiry, keyId})
-  // Generate a signature from the full URL with the new parameters
-  const signature = generateSignature(urlWithParams, privateKey)
-  // Append the signature using string concatenation instead of URLSearchParams
-  // to ensure the signature is not URL-encoded (e.g. '=' to '%3D')
-  const urlWithSignature = `${urlWithParams.toString()}&signature=${signature}`
+  const urlObj = new URL(url)
+  // Extract user-defined query parameters, excluding reserved signing parameters
+  const userParams = extractUserParams(urlObj)
+  // Canonicalize the query string from the user parameters
+  const canonicalQuery = getCanonicalQuery(userParams)
+  // Get the URL with signing parameters (keyid and optional expiry)
+  const urlToSign = urlWithSigningParams(urlObj, canonicalQuery, options)
+  // Generate a signature from the fully canonicalized URL
+  const signature = generateSignature(urlToSign, options.privateKey)
+  // Append the RFC 3986 encoded signature
+  const urlWithSignature = `${urlToSign}&signature=${rfc3986(signature)}`
   return urlWithSignature
 }
 
@@ -52,27 +93,28 @@ export function signUrl(url: string | URL, options: SigningOptions): string {
  *
  * @public
  * @param url - The base URL to which signing parameters will be added
+ * @param query - The canonical query string of user parameters
  * @param options - The signing options containing keyId and optional expiry
- * @returns A URL object with keyid and expiry parameters added
+ * @returns A "signable" URL string with keyid and expiry parameters
  */
 export function urlWithSigningParams(
   url: string | URL,
-  options: Omit<SigningOptions, 'privateKey'>,
-): URL {
-  const {expiry, keyId} = options
-  const urlObj = new URL(url)
-  // Remove existing params to ensure new ones are added in the correct order.
-  urlObj.searchParams.delete('keyid')
-  urlObj.searchParams.delete('expiry')
-  urlObj.searchParams.delete('signature')
+  query: string,
+  signingOptions: Omit<SigningOptions, 'privateKey'>,
+): string {
+  const {origin, pathname} = new URL(url)
+  const parts = [origin, pathname, '?']
 
-  // Append the signing specific parameters. `set` or `append` after `delete`
-  // will have the same effect, but use `append` to be explicit.
-  urlObj.searchParams.append('keyid', keyId)
-  const expiryStr = normalizeExpiry(expiry)
-  if (expiryStr) {
-    urlObj.searchParams.append('expiry', expiryStr)
+  if (query.length > 0) {
+    parts.push(query)
+    parts.push('&')
   }
 
-  return urlObj
+  parts.push(`keyid=${rfc3986(signingOptions.keyId)}`)
+
+  if (signingOptions.expiry) {
+    parts.push(`&expiry=${rfc3986(normalizeExpiry(signingOptions.expiry) ?? '')}`)
+  }
+
+  return parts.join('')
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,5 @@
+export type Param = [string, string]
+
 /**
  * Options for signing URLs with Ed25519
  *

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,5 @@
+import type {Param} from './types'
+
 /**
  * Converts a base64 string to a byte array.
  *
@@ -91,6 +93,32 @@ export function extractPemContents(pem: string): string {
 }
 
 /**
+ * Lexicographically sorts two [key, value] parameter tuples.
+ *
+ * Sorting is first by key, then by value if keys are identical.
+ *
+ * @internal
+ * @param a - The first parameter tuple to compare
+ * @param b - The second parameter tuple to compare
+ * @returns A negative number if a < b, positive if a > b, or 0 if equal
+ */
+export function lexographicSort(a: Param, b: Param): number {
+  const [keyA, valueA] = a
+  const [keyB, valueB] = b
+
+  // First compare the keys
+  if (keyA < keyB) return -1
+  if (keyA > keyB) return 1
+
+  // Keys are equal → compare the values
+  if (valueA < valueB) return -1
+  if (valueA > valueB) return 1
+
+  // Keys and values are identical
+  return 0
+}
+
+/**
  * Normalizes base64url encoding to match RFC 4648 "URL and Filename Safe"
  * Base64 Alphabet, but with padding. Replaces '+' with '-', and '/' with '_',
  * but maintains '=' padding.
@@ -132,6 +160,23 @@ export function normalizeExpiry(expiry: Date | number | string | undefined): str
 
   // Format as 'YYYY-MM-DDTHH:mm:ssZ' (strip milliseconds)
   return date.toISOString().replace(/\.\d{3}Z$/, 'Z')
+}
+
+/**
+ * Encodes a string per RFC 3986 for use in URLs.
+ *
+ * This function uses `encodeURIComponent` and additionally encodes
+ * characters that are not encoded by it: `!'()*`
+ *
+ * @internal
+ * @param str - The string to encode
+ * @returns The RFC 3986 encoded string
+ */
+export function rfc3986(str: string) {
+  return encodeURIComponent(str).replace(
+    /[!'()*]/g,
+    (c) => `%${c.charCodeAt(0).toString(16).toUpperCase()}`,
+  )
 }
 
 /**

--- a/test/signing.test.ts
+++ b/test/signing.test.ts
@@ -53,15 +53,6 @@ describe('generateSignature', () => {
     expect(signature1).toMatch(/^[A-Za-z0-9_-]+={0,2}$/) // Base64url format with optional padding
   })
 
-  it('should handle URL objects', () => {
-    const urlObject = new URL(baseUrl)
-
-    const signature1 = generateSignature(baseUrl, TEST_PRIVATE_KEY)
-    const signature2 = generateSignature(urlObject, TEST_PRIVATE_KEY)
-
-    expect(signature1).toBe(signature2)
-  })
-
   it('should handle URLs with query parameters', () => {
     const url = `${baseUrl}?w=200&h=300`
 


### PR DESCRIPTION
This includes breaking changes to introduce canonical query parameters with RFC 3986 compliant encoding:

- Implemented lexicographic sorting of query parameters
- Added helper functions for extracting user parameters and generating canonical queries
- Refactored the URL signing process to use canonical query strings
- Added proper RFC 3986 encoding for URL parameters and signatures
- Updated the sign script to use the new canonical query approach
- Fixed URL parameter handling to ensure consistent signatures